### PR TITLE
add pymongo[srv] to resolve dns seed list for urls like mongodb+srv://

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django>=3.2,<4.0
 djangorestframework>=3.12,<4.0
 django-cors-headers>=3.5,<4.0
 pymongo>=3.11,<4.0
+pymongo[srv]>=3.11,<4.0


### PR DESCRIPTION
# What does this PR do?
- received a  error message which indicates that when you use a MongoDB connection string that starts with mongodb+srv://, pymongo requires the dnspython module to be installed. Without it, pymongo cannot resolve the DNS seed list provided in such URIs.